### PR TITLE
fix JSON Schema for extension settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,13 @@
       "commandPalette": []
     },
     "configuration": {
-      "linkPreviewExpander.corsAnywhereUrl": {
-        "description": "The URL to a CORS proxy.",
-        "type": "string",
-        "default": "https://cors-anywhere.herokuapp.com"
+      "title": "link-preview-expander settings",
+      "properties": {
+        "linkPreviewExpander.corsAnywhereUrl": {
+          "description": "The URL to a CORS proxy.",
+          "type": "string",
+          "default": "https://cors-anywhere.herokuapp.com"
+        }
       }
     }
   },


### PR DESCRIPTION
The `linkPreviewExpander.corsAnywhereUrl` property was missing a `properties` object above it to define the JSON Schema correctly. This fix makes it so that the user settings Monaco editor in Sourcegraph properly completes and validates this property.